### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -97,16 +97,5 @@ file.
 
 [LICENSE]: ./LICENSE
 
-About thoughtbot
-----------------
-
-![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
-
-This module is maintained and funded by thoughtbot, inc. The names and logos
-for thoughtbot are trademarks of thoughtbot, inc.
-
-We love open source software! See [our other projects][community] or [hire
-us][hire] to design, develop, and grow your product.
-
-[community]: https://thoughtbot.com/community?utm_source=github
-[hire]: https://thoughtbot.com/hire-us?utm_source=github
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.